### PR TITLE
Swan

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :green_heart:  | STM32L4S7ZITx | Generic Board | *2.0.0* |  |
 | :green_heart:  | STM32L4S9ZIJx | Generic Board | *2.0.0* |  |
 | :yellow_heart:  | STM32L4S9ZIYx | Generic Board | **2.1.0** |  |
-| :yellow_heart:  | STM32L4R5ZIYx | Swan | **2.1.0** | [Blues Wireless](https://blues.io/) |
+| :yellow_heart:  | STM32L4R5ZIYx | Swan R5 | **2.1.0** | [Blues Wireless](https://blues.io/) |
 
 ### Generic STM32L5 boards
 

--- a/boards.txt
+++ b/boards.txt
@@ -4408,7 +4408,7 @@ GenL4.build.series=STM32L4xx
 GenL4.build.cmsis_lib_gcc=arm_cortexM4lf_math
 
 # Swan
-GenL4.menu.pnum.SWAN=Swan
+GenL4.menu.pnum.SWAN=Swan R5
 GenL4.menu.pnum.SWAN.upload.maximum_size=2097152
 GenL4.menu.pnum.SWAN.upload.maximum_data_size=655360
 GenL4.menu.pnum.SWAN.build.board=SWAN

--- a/variants/STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY/PeripheralPins_SWAN.c
+++ b/variants/STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY/PeripheralPins_SWAN.c
@@ -15,7 +15,7 @@
  * STM32L4S5ZIYx.xml, STM32L4S9ZIYx.xml
  * CubeMX DB release 6.0.21
  */
-#if defined(ARDUINO_SWAN)
+#if defined(ARDUINO_SWAN_R5)
 #include "Arduino.h"
 #include "PeripheralPins.h"
 
@@ -476,4 +476,4 @@ WEAK const PinMap PinMap_SD[] = {
 };
 #endif
 
-#endif /* ARDUINO_SWAN */
+#endif /* ARDUINO_SWAN_R5 */

--- a/variants/STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY/variant_SWAN.cpp
+++ b/variants/STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY/variant_SWAN.cpp
@@ -10,7 +10,7 @@
  *
  *******************************************************************************
  */
-#if defined(ARDUINO_SWAN)
+#if defined(ARDUINO_SWAN_R5)
 #include "pins_arduino.h"
 
 // Digital PinName array
@@ -185,4 +185,4 @@ WEAK void SystemClock_Config(void)
 #ifdef __cplusplus
 }
 #endif
-#endif /* ARDUINO_SWAN* */
+#endif /* ARDUINO_SWAN_R5* */

--- a/variants/STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY/variant_SWAN.h
+++ b/variants/STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY/variant_SWAN.h
@@ -182,8 +182,8 @@
 #endif
 
 // On-board user button
-#ifndef POWER_SWITCH
-  #define POWER_SWITCH          PE4
+#ifndef ENABLE_3V3
+  #define ENABLE_3V3          PE4
 #endif
 
 // I2C definitions

--- a/variants/STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY/variant_SWAN.h
+++ b/variants/STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY/variant_SWAN.h
@@ -181,6 +181,11 @@
   #define USER_BTN              PC13
 #endif
 
+// On-board user button
+#ifndef POWER_SWITCH
+  #define POWER_SWITCH          PE4
+#endif
+
 // I2C definitions
 #ifndef PIN_WIRE_SDA
   #define PIN_WIRE_SDA          PB7


### PR DESCRIPTION
**Summary**

- Rename Swan to Swan R5 for future compatibility
- Add an `ENABLE_3V3` alias to PE4. This pin, when pulled High, enables 3V3 OUT on the Swan so we'd like to add this for ease of use.